### PR TITLE
Tweak grammar for Swift 2

### DIFF
--- a/grammars/swift.cson
+++ b/grammars/swift.cson
@@ -7,19 +7,23 @@
 'patterns': [
   {
     'name': 'keyword.declaration.swift'
-    'match': '\\b(class|deinit|enum|extension|final|import|init|internal|let|private|protocol|public|static|struct|subscript|typealias|var)\\b'
+    'match': '\\b(class|deinit|enum|extension|import|init|inout|internal|let|operator|private|protocol|public|static|struct|subscript|typealias|var)\\b'
   }
   {
     'name': 'keyword.statement.swift'
-    'match': '\\b(break|case|continue|default|do|else|fallthrough|if|in|for|return|switch|where|while)\\b'
+    'match': '\\b(break|case|continue|default|defer|do|else|fallthrough|for|guard|if|in|repeat|return|switch|where|while)\\b'
   }
   {
     'name': 'keyword.expressions-and-types.swift'
-    'match': '\\b(as|dynamicType|is|new|super|self|Self|Type|__COLUMN__|__FILE__|__FUNCTION__|__LINE__)\\b'
+    'match': '\\b(as|catch|dynamicType|false|is|nil|rethrows|super|self|Self|throw|throws|true|try|__COLUMN__|__FILE__|__FUNCTION__|__LINE__)\\b'
+  }
+  {
+    'name': 'keyword.patterns.swift'
+    'match': '\\b(_)\\b'
   }
   {
     'name': 'keyword.reserved.swift'
-    'match': '\\b(associativity|didSet|get|infix|inout|left|mutating|none|nonmutating|operator|override|postfix|precedence|prefix|right|set|unowned|unowned\(safe\)|unowned\(unsafe\)|weak|willSet)\\b'
+    'match': '\\b(associativity|convenience|dynamic|didSet|final|get|infix|lazy|left|mutating|none|nonmutating|optional|override|postfix|precedence|prefix|Protocol|required|right|set|Type|unowned|weak|willSet)\\b'
   }
   {
     'include': '#comment'


### PR DESCRIPTION
Mainly added some new keywords in Swift 2, such as `repeat`, `defer`, `throw`, `try`, `catch` and some other.

Also adjusted some keywords type, based on the language reference. See the "Keywords and Punctuation" of [this page](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html#//apple_ref/doc/uid/TP40014097-CH30-ID410) for more.