### PR TITLE
Revamp and update the snippets

### DIFF
--- a/snippets/language-swift.cson
+++ b/snippets/language-swift.cson
@@ -1,7 +1,119 @@
 '.source.swift':
-  'println("...")':
-    'prefix': 'pr'
-    'body': 'println("$1")$0'
-  'println("\\(...)")':
-    'prefix': 'po'
-    'body': 'println("\\($1)")$0'
+  'print()':
+    'prefix': 'print'
+    'body': 'print("$1")$0'
+  'Closure':
+    'prefix': 'closure'
+    'body': '{ (${1:parameters}) -> ${2:type} in ${3:body} }$0'
+  'Function':
+    'prefix': 'func'
+    'body': '''
+    func ${1:name}() {
+        ${2:body}
+    }
+    '''
+  'Initializer':
+    'prefix': 'init'
+    'body': '''
+    init() {
+        ${1:body}
+    }
+    '''
+  'Deinitializer':
+    'prefix': 'deinit'
+    'body': '''
+    deinit {
+        ${1:body}
+    }
+    '''
+  'Class':
+    'prefix': 'class'
+    'body': '''
+    class ${1:name} {
+        ${2:body}
+    }
+    '''
+  'Extension':
+    'prefix': 'extension'
+    'body': '''
+    extension ${1:type} {
+      ${2:body}
+    }
+    '''
+  'Structure':
+    'prefix': 'struct'
+    'body': '''
+    struct ${1:name} {
+        ${2:body}
+    }
+    '''
+  'Enumeration':
+    'prefix': 'enum'
+    'body': '''
+    enum ${1:name} {
+        ${2:body}
+    }
+    '''
+  'Do-Catch Statement':
+    'prefix': 'do'
+    'body': '''
+    do {
+        ${2:body}
+    } catch ${1:ErrorType} {
+        $3
+    } catch {
+        $4
+    }
+    '''
+  'If Statement':
+    'prefix': 'if'
+    'body': '''
+    if ${1:condition} {
+        ${2:body}
+    }
+    '''
+  'Switch Statement':
+    'prefix': 'switch'
+    'body': '''
+    switch ${1:value} {
+    case ${2:value}:
+        $3
+    default:
+        $4
+    }
+    '''
+  'Guard Statement':
+    'prefix': 'guard'
+    'body': '''
+    guard ${1:expression} else {
+        ${2:body}
+    }
+    '''
+  'While Loop':
+    'prefix': 'while'
+    'body': '''
+    while ${1:condition} {
+        ${2:body}
+    }
+    '''
+  'Repeat-While Loop':
+    'prefix': 'repeat'
+    'body': '''
+    repeat {
+        ${1:body}
+    } while ${2:condition}
+    '''
+  'For Loop':
+    'prefix': 'cfor'
+    'body': '''
+    for ${1:initialization}; ${2:condition}; ${3:incrementer} {
+        ${4:body}
+    }
+    '''
+  'For-In Loop':
+    'prefix': 'for'
+    'body': '''
+    for ${1:var} in ${2:value} {
+        ${3:body}
+    }
+    '''


### PR DESCRIPTION
I've added snippets for common language constructs such as if statements, for-in statements, `print()`, `class`, `struct`, `enum`, etc.