### PR TITLE
Make return type match up to end of class name

### DIFF
--- a/grammars/swift.cson
+++ b/grammars/swift.cson
@@ -307,7 +307,7 @@
       }
       {
         'name': 'meta.return-type.swift'
-        'match': '((->)\\s*([^\\{]+))'
+        'match': '((->)\\s*([^\\{\\s]+))'
         'captures':
           '2':
             'name': 'punctuation.function.swift'


### PR DESCRIPTION
Fixes the syntax highlighting part of #23.

I'll be honest in saying that I'm just starting out with Swift so my knowledge of syntax isn't the greatest but this was really bothering me. If there's some case where there's multiple words after the `->` this isn't valid but if the syntax is only ever `-> ClassName {` this should word.