### PR TITLE
Xcode 8 Beta 6 + Swift 3 // New access modifiers

### DIFF
--- a/grammars/swift.cson
+++ b/grammars/swift.cson
@@ -7,7 +7,7 @@
 'patterns': [
   {
     'name': 'keyword.declaration.swift'
-    'match': '\\b(class|deinit|enum|extension|final|import|init|internal|let|private|protocol|public|static|struct|subscript|typealias|var)\\b'
+    'match': '\\b(class|deinit|enum|extension|final|import|init|internal|let|private|protocol|public|static|struct|subscript|typealias|var|open|fileprivate)\\b'
   }
   {
     'name': 'keyword.statement.swift'

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name"        : "language-swift",
-  "version"     : "0.3.0",
-  "description" : "Swift language support in Atom",
-  "license"     : "MIT",
-  "homepage"    : "https://github.com/darinmorrison/atom-language-swift",
-  "repository"  : "https://github.com/darinmorrison/atom-language-swift",
-  "engines"     : {
-    "atom"  : ">= 0.100.0"
+  "name": "language-swift",
+  "version": "0.4.0",
+  "description": "Swift language support in Atom",
+  "license": "MIT",
+  "homepage": "https://github.com/darinmorrison/atom-language-swift",
+  "repository": "https://github.com/darinmorrison/atom-language-swift",
+  "engines": {
+    "atom": ">= 0.100.0"
   },
-  "bugs"        : {
-    "url"   : "https://github.com/darinmorrison/atom-language-swift/issues"
+  "bugs": {
+    "url": "https://github.com/darinmorrison/atom-language-swift/issues"
   }
 }


### PR DESCRIPTION
Added `open` and `fileprivate` as new access modifiers
*fileprivate* has been proposed as SE-0025 and *open* was proposed under SE-0117

More info at [Xcode 8 Beta 6 Release Notes](http://adcdownload.apple.com/Developer_Tools/Xcode_8_beta_6/Release_Notes_for_Xcode_8_beta_6.pdf)